### PR TITLE
Sanitize and escape options

### DIFF
--- a/inc/razorpay/class-camptix-payment-method-razorpay.php
+++ b/inc/razorpay/class-camptix-payment-method-razorpay.php
@@ -128,13 +128,13 @@ class CampTix_Payment_Method_RazorPay extends CampTix_Payment_Method {
 		$merchant = $this->get_merchant_credentials();
 
 		$data = array(
-			'merchant_key_id' => $merchant['key_id'],
+			'merchant_key_id' => esc_js( $merchant['key_id'] ),
 			'gateway_id'      => $this->id,
 			'popup'           => array(
-				'color' => apply_filters( 'camptix_razorpay_popup_color', '' ),
+				'color' => esc_js( apply_filters( 'camptix_razorpay_popup_color', '' ) ),
 
 				// Ideal logo size: https://i.imgur.com/n5tjHFD.png
-				'image' => apply_filters( 'camptix_razorpay_popup_logo_image', '' ),
+				'image' => esc_js( apply_filters( 'camptix_razorpay_popup_logo_image', '' ) ),
 			),
 		);
 
@@ -285,7 +285,7 @@ class CampTix_Payment_Method_RazorPay extends CampTix_Payment_Method {
 		$output = $this->options;
 
 		if ( isset( $input['razorpay_popup_title'] ) ) {
-			$output['razorpay_popup_title'] = $input['razorpay_popup_title'];
+			$output['razorpay_popup_title'] = wp_kses_post( $input['razorpay_popup_title'] );
 		}
 
 		if ( isset( $input['live_key_id'] ) ) {


### PR DESCRIPTION
Remove unfiltered HTML from Razorpay modal title, like `<script>` tags.
And escape JS before include into `wp_localize_script()`.